### PR TITLE
Logic bug in captura/template/renderer.py

### DIFF
--- a/captura/template/renderer.py
+++ b/captura/template/renderer.py
@@ -66,4 +66,4 @@ def render_all(path: Path, config: Config, values: dict) -> None:
         logger.debug("Copying assets...")
         for asset in config.assets:
             logger.debug(f"Copying asset {asset}...")
-            shutil.copy(path / asset, path / asset)
+            shutil.copy(config.get_directory() / "files" / asset, path / asset)


### PR DESCRIPTION
Fixes #18

There was a logic bug in captura.template.renderer:render_all where the program tried to copy the asset from the destination directory, instead of from the template directory. This has been fixed.